### PR TITLE
Use sphinx markdown parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'sphinx',
         'sphinx-rtd-theme',
         'recommonmark',
+        'sphinx-markdown-parser',
         'nbsphinx',
     ],
     package_data={

--- a/src/starterkit_ci/__init__.py
+++ b/src/starterkit_ci/__init__.py
@@ -63,7 +63,7 @@ def deploy_docs(source_dir, allow_warnings=False):
     check_call(['git', 'config', 'user.name', 'Alex Pearce'], cwd=built_dir)
     check_call(['git', 'config', 'user.email', 'alex@alexpearce.me'], cwd=built_dir)
 
-    push_url = 'https://' + os.environ['GH_TOKEN'] + '@github.com/lhcb/starterkit-lessons.git'
+    push_url = 'https://' + os.environ['GH_TOKEN'] + '@github.com/' + os.environ['TRAVIS_REPO_SLUG'] + '.git'
     check_call(['git', 'remote', 'add', 'upstream', push_url], cwd=built_dir)
     check_call(['git', 'fetch', 'upstream'], cwd=built_dir)
     check_call(['git', 'reset', 'upstream/gh-pages'], cwd=built_dir)

--- a/src/starterkit_ci/sphinx_config/__init__.py
+++ b/src/starterkit_ci/sphinx_config/__init__.py
@@ -1,7 +1,9 @@
 import os
 from os.path import dirname, join
 
-from recommonmark.transform import AutoStructify
+from sphinx_markdown_parser.parser import MarkdownParser
+from recommonmark.parser import CommonMarkParser
+from sphinx_markdown_parser.transform import AutoStructify
 
 from . import panels
 from . import fix_markdown_file_downloads
@@ -9,7 +11,7 @@ from . import fix_markdown_file_downloads
 
 extensions = [
     'sphinx_rtd_theme',
-    'recommonmark',
+    'sphinx_markdown_parser',
     'sphinx.ext.mathjax',
     'nbsphinx',
 ]
@@ -60,12 +62,23 @@ starterkit_ci_redirects = {}
 
 
 def setup(app):
-    app.add_config_value('recommonmark_config', {
-        # 'url_resolver': lambda url: 'http://0.0.0.0/' + url,
-        'auto_toc_tree_section': 'Contents',
-        'enable_math': True,
-        'enable_inline_math': True,
+    app.add_source_suffix('.md', 'markdown')
+    #app.add_source_parser(MarkdownParser)
+    app.add_source_parser(CommonMarkParser)
+    app.add_config_value('markdown_parser_config', {
+        'auto_toc_tree_section': 'Content',
+        'enable_auto_doc_ref': True,
+        'enable_auto_toc_tree': True,
         'enable_eval_rst': True,
+        'extensions': [
+            'extra',
+            'nl2br',
+            'sane_lists',
+            'smarty',
+            'toc',
+            'wikilinks',
+            'pymdownx.arithmatex',
+        ],
     }, True)
     app.add_transform(AutoStructify)
     fix_markdown_file_downloads.configure_app(app)


### PR DESCRIPTION
Motivation is to avoid this issue for which it doesn't seem like a PR will be merged: https://github.com/readthedocs/recommonmark/pull/178

This should probably also involve using `MarkdownParser` instead of `CommonMarkParser` but I'm having trouble getting that to work.

I haven't made sense of what's broken but it can be hacked by changing:

https://github.com/Python-Markdown/markdown/blob/b701c34ebd7b2d0eb319517b9a275ddf0c89608d/markdown/extensions/footnotes.py#L25

to `etree = util.etree` and deleting this assertion:

https://github.com/codejamninja/sphinx-markdown-parser/blob/2fd54373770882d1fb544dc6524c581c82eedc9e/sphinx_markdown_parser/markdown_parser.py#L293

I'll give up for now and open an issue.