### PR TITLE
Fix build and linkcheck

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         }
     },
     project_urls={
-        'Bug Reports': 'https://github.com/lhcb/starterkit_ci/issues',
-        'Source': 'https://github.com/lhcb/starterkit_ci',
+        'Bug Reports': 'https://github.com/lhcb/starterkit-ci/issues',
+        'Source': 'https://github.com/lhcb/starterkit-ci',
     },
 )

--- a/src/starterkit_ci/sphinx_config/__init__.py
+++ b/src/starterkit_ci/sphinx_config/__init__.py
@@ -53,6 +53,8 @@ linkcheck_ignore = [
     r'https://gitlab\.cern\.ch/lhcb/Stripping/blob/.*',
     # Seems to be unreliable?
     r'http://pdg.*\.lbl\.gov/.*',
+    # 403 if not logged in
+    r'https://groups\.cern\.ch/group/lhcb-distributed-analysis/default\.aspx',
     # FIXME: The URLs have changed
     r'https://research\.cs\.wisc\.edu/htcondor/.*',
 ]

--- a/src/starterkit_ci/sphinx_config/__init__.py
+++ b/src/starterkit_ci/sphinx_config/__init__.py
@@ -64,9 +64,14 @@ starterkit_ci_redirects = {}
 
 
 def setup(app):
+    # Workaround for https://github.com/readthedocs/recommonmark/issues/177
+    class CustomCommonMarkParser(CommonMarkParser):
+        def visit_document(self, node):
+            pass
+
     app.add_source_suffix('.md', 'markdown')
     #app.add_source_parser(MarkdownParser)
-    app.add_source_parser(CommonMarkParser)
+    app.add_source_parser(CustomCommonMarkParser)
     app.add_config_value('markdown_parser_config', {
         'auto_toc_tree_section': 'Content',
         'enable_auto_toc_tree': True,


### PR DESCRIPTION
- Workaround for `.../recommonmark/parser.py:75: UserWarning: Container node skipped: type=document` (see https://github.com/readthedocs/recommonmark/issues/177)
- Ignore egroup archive link in linkcheck (needs auth)
- Fix project URLs