### PR TITLE
Work around Docutils deprecation warning.

### DIFF
--- a/src/starterkit_ci/sphinx_config/panels.py
+++ b/src/starterkit_ci/sphinx_config/panels.py
@@ -31,7 +31,7 @@ class AddPanels(SphinxTransform):
     }
 
     def apply(self, **kwargs):
-        for node in self.document.traverse(nodes.Element)[::-1]:
+        for node in reversed(list(self.document.traverse(nodes.Element))):
             match = re.match(r'^ *{%\s*(\w+)\s*"([^"]+)"\s*%} *$', node.rawsource)
             if match:
                 panel_type, title = match.groups()


### PR DESCRIPTION
The warning shows up in [Starterkit lesson CI builds](https://travis-ci.org/github/lhcb/starterkit-lessons/builds/759010571):

```
/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/starterkit_ci/sphinx_config/panels.py:34: FutureWarning: 
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  for node in self.document.traverse(nodes.Element)[::-1]:
```